### PR TITLE
Fix typo in showpic.js that fails to enlarge image

### DIFF
--- a/browse/showpic.js
+++ b/browse/showpic.js
@@ -294,7 +294,7 @@ function ShowDetails(){
 function SizeImage()
 {
     if (ShowBigOn){
-        vc.width = vc.natualWidth;
+        vc.width = vc.naturalWidth;
         vc.height = vc.naturalHeight;
         return;
     }


### PR DESCRIPTION
This PR fixes a bug where clicking the "Enlarge" button sets with width to `0`and no image is  shown.