### PR TITLE
Several new features:

### DIFF
--- a/browse/realtime.html
+++ b/browse/realtime.html
@@ -4,7 +4,7 @@
   body { font-family: sans-serif; font-size: 22; }
 </style>
 <body>
-<img id='rti' src="/view.cgi?now.jpg" onload="sizeImage()" width=100 height=60>
+<img id='rti' src="view.cgi?now.jpg" onload="sizeImage()" width=100 height=60>
 <br>
 <small>
 <!--<span id="imgseq">Sequence</span><br>-->

--- a/browse/showdir.c
+++ b/browse/showdir.c
@@ -54,7 +54,7 @@ static void PrintNavLinks(Dir_t * Dir, int IsRoot)
             printf("<a href=\"view.cgi?%s\">[Saved]</a>\n",SavedDir+4);
         }
     }
-    printf("<a href='/realtime.html'>[Realtime]</a>\n");
+    printf("<a href='realtime.html'>[Realtime]</a>\n");
     printf("<a href='view.cgi?actagram'>[Actagram]</a>\n");
 }
 

--- a/browse/view.c
+++ b/browse/view.c
@@ -270,18 +270,20 @@ void DoSaveImage(char * QueryString, char * HtmlPath)
 }
 
 //----------------------------------------------------------------------------------
-// Dump latest qauired image in /ramdisk.
+// Dump latest acquired image in /ramdisk or custom "in" directory.
 //----------------------------------------------------------------------------------
 void ShowLatestJpg(void)
 {
     VarList files;
 
+    char *dirname = access("in",F_OK) ? "/ramdisk" : "in";
+    
     memset(&files, 0, sizeof(files));
-    CollectDirectory("/ramdisk", &files, NULL, ImageExtensions);
+    CollectDirectory(dirname, &files, NULL, ImageExtensions);
     
     if (files.NumEntries){
         char InName[100];
-        sprintf(InName, "/ramdisk/%s",files.Entries[files.NumEntries-1].Name);
+        sprintf(InName, "%s/%s",dirname,files.Entries[files.NumEntries-1].Name);
         
         printf("Content-Type: image/jpg\n\n");
         //printf("input file name = %s\n",InName);
@@ -289,6 +291,7 @@ void ShowLatestJpg(void)
         {
             unsigned char Chunk[4096];
             FILE * infile = fopen(InName, "rb");
+
             for (;;){
                 int nr = fread(Chunk, 1, 4096, infile);
                 if (nr <= 0) break;

--- a/browse/wait_change.c
+++ b/browse/wait_change.c
@@ -25,11 +25,20 @@ int main()
     FILE * LogFile;
     long FileSize;
     
-    const char *WATCH_FILE = "/ramdisk/log.txt";
+    char *WATCH_FILE;
     
     printf("Content-Type: text/html\n\n<html>\n"); // html header
-    
-    LogFile = fopen(WATCH_FILE, "r");
+ 
+    // First try to follow symlink "in" in the current directory.  Only if that fails,
+    // use the hardcoded path to ramdisk.
+   
+    WATCH_FILE = "in/log.txt"; LogFile = fopen(WATCH_FILE,"r");
+
+    if (LogFile == NULL) {
+        WATCH_FILE = "/ramdisk/log.txt";
+        LogFile = fopen(WATCH_FILE, "r");
+    }
+
     if (LogFile == NULL){
         printf("Error!  No log.txt file\n");
         sleep(1); // To keep from cycling too fast.

--- a/conf-examples/imgcomp.conf.rtsp-camera
+++ b/conf-examples/imgcomp.conf.rtsp-camera
@@ -1,0 +1,61 @@
+# Imgcomp test configruation file
+# Please see docs/config.html for more details on cofiguring Imgcomp
+
+# The command to start aquiring
+#
+# ffmpeg arguments are as follows
+#
+# -rtsp_transport tcp          Needed because otherwise it does an UDP protocol which (with my cameras) glitches
+# -i url                       Whatever magic URL is needed to access the HD stream from the camera.  This one works for any default-configured Hikvision camera
+# -q:v 1                       Good quality jpegs.  The default ones are really bad
+# -r 2                         Extract 2 jpeg frames per second from the stream.  Not sure ffmpeg always respects this
+# 
+aquire_cmd = ffmpeg -rtsp_transport tcp -i rtsp://192.168.1.15:554/user=admin&password=&channel=1&stream=0.sdp -q:v 1 -r 2 /tmp/in2/%06d.jpg
+#
+# raspistill creates the files first with a ~ suffix, then renames.  So waiting for an IN_CREATE event is appopriate.  But
+# ffmpeg creates the files empty, then writes to them.  Without switching to IN_CLOSE_WRITE we get lots of empty or partial files.
+#
+wait_close_write = 1
+#
+# imgcomp will kill and restart the acquisition program if no pictures come.  With rapsistill, the default 6 second timeout is fine,
+# but RTSP cameras are physically remote to where the imgcomp program runs, and sometimes pause for reasons unknown to the point where
+# the 6 second timeout fires (and then recover).  So increase the timeout.
+#
+relaunch_timeout = 30
+#
+# By default, after about 15 seconds of unsuccessfully relaunching raspistill, imgcomp will give up and try to reboot the Raspi.
+# With an RTSP camera this makes no sense, since the camera is remote.  So we might as well wait indefinitely for it to come back.
+# Note setting this to nonzero allows a timeout in seconds to be specified; zero means never time out.
+#
+give_up_timeout = 0
+
+# Directory to get images from as they are aquired
+# (aquire_cmd must also indicate to put images there)
+followdir = /tmp/in2
+
+# Specify a map of which parts of the image to ignore.
+# Solid blue ares are ignored, solid red is twice as sensitive.
+# any other colour in the image is treated as normal detection area.
+#diffmap = diffmap.jpg
+
+# Turn on spurious reject
+spurious = 1
+
+# Where to save interesting images to. Note this particular configuration uses /tmp/in2 and /tmp/saved2.  Without an anxillary script
+# to move the pictures off the Raspi, memory will quickly run out.
+savedir = /tmp/saved2
+
+brmonitor = 0
+
+# Where to save images that have changes.  One directory per day
+# with subdirectories for each hour.  This is also the default naming
+# scheme, and is required directory structure for the HTML image browser
+savenames = %y%m%d/%H/%m%d-%H%M%S
+
+# How many seconds between images kept regardless of motion for timelapses.
+#timelapse = 1200
+
+sensitivity = 200
+
+logtofile = /tmp/in2/log.txt
+#movelognames = images/%y%m%d/%H/Log.html

--- a/conf-examples/movefiles-shellscript
+++ b/conf-examples/movefiles-shellscript
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This needs customization to use!  You need ssh login credentials on the server
+# where the files are to be transfered and then set up the appropriate sync_to lines
+# as in the example below.
+
+function sync_to() {
+   touch /tmp/sync_timestamp
+   rsync -rl -e ssh . $1
+   retVal=$?
+   echo "rsync returned $retVal"
+   if [ $retVal -eq 0 ]; then
+      echo "nuking old files"
+      find . -type f ! -newer /tmp/sync_timestamp -delete
+   fi
+}
+
+while true;do
+   # This script will blindly MOVE files (i.e. delete the local copy) elsewhere
+   # If the cd to a /tmp/blah directory fails becaue that directory doesn't exist,
+   # it'll happily move everything in your home directory!  As a simple fix, go
+   # to /tmp first on the assumption that that always exists.
+   # somewhere
+   cd /tmp
+   echo "sync started"
+   cd /tmp/saved1
+   sync_to imgcomp3@192.168.0.1:/web/cameras/backyard/saved
+   cd /tmp/saved2
+   sync_to imgcomp3@192.168.0.1:/web/cameras/driveway/saved
+   cd /tmp/saved3
+   sync_to imgcomp3@192.168.0.1:/web/cameras/basement_stairs/saved
+   echo "sleep started"
+   sleep 60
+done

--- a/docs/config.html
+++ b/docs/config.html
@@ -154,3 +154,21 @@ to use the Realtime display, otherwise you will see an error when accessing the 
 Where to copy logs files to.  I normally have it copy the log file to the pictures
 directory every hour, so that it's easy to find the log file that goes with the pictures.
 
+<div class="p">configfile</div>
+If this is given as part of the command line parameters, it overrides the default "imgcomp.conf"
+for the default options.  This is for running multiple imgcomp instances in the same user account
+for multiple cameras.
+
+<div class="p">wait_close_write</div>
+If this is set to nonzero, the inotify watch for new pictures to appear uses IN_CLOSE_WRITE
+rather than IN_CREATE.  This works properly with ffmpeg as as source of pictures.
+
+<div class="p">relaunch_timeout</div>
+If this is set, it replaces the default 5 seconds until imgcomp gives up on the capture
+program, kills it and restarts it.  RTSP cameras with ffmpeg benefit from a longer timeout.
+
+<div class="p">give_up_timeout</div>
+If this is set, it replaces the default 15 seconds from last valid picture seen, until
+imgcomp gives up and tries (assuming it has permission) to reboot the Raspberry Pi.  Highly
+recommended to set if imgcomp is running on something other than a dedicated Raspi, e.g.
+watching an RTSP camera as a normal process on a multiuser Linux machine.

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,5 +123,6 @@ to ignore these spurious changes.
 <b>
 See also:
 <p>
+<a href="rtsp_cams.html">How to use imgcomp with RTSP (ONVIF) network cameras</a><p>
 <a href="config.html">Imgcomp configuration parameters</a><p>
 <a href="http://woodgears.ca/imgcomp/diffmap.html">Imgcomp detection regions</a><p>

--- a/docs/rtsp_cams.html
+++ b/docs/rtsp_cams.html
@@ -1,0 +1,79 @@
+<html>
+<head>
+<title>Imgcomp RTSP camera documentation</title>
+<style type=text/css>
+  body { font-family: sans-serif; font-size: 100%;}
+  div.c { white-space: pre; font-family: monospace; font-weight: bold; font-size: 120%;}
+  span.c { font-family: monospace; font-weight: bold; font-size: 120%;}
+</style></head>
+
+<h2>Why RTSP cameras?</h2>
+What is here called an RTSP camera is any camera that claims to be "ONVIF" compliant.
+Generally these use Hikvision chipsets, and can only be configured using an ActiveX plugin
+running on an obsolete Windows browser and only accessed by pulling a H.264 stream via
+the RTSP protocol.  They're meant to be used with continuously recording surveillance
+boxes.
+<p>
+But they're also cheap.  At the time of this writing (April 2020) it is possible to
+obtain a 1080p, wide-angle (2.8mm lens, approximately 90 degree angle of vision horizontally)
+PoE powered, weatherproof camera for about Can$35 directly from China via Ali Express.
+The picture quality is not as good as that of a Raspicam, but you don't need one Raspi
+per camera; one Raspi3 can easily handle 3 or 4 of them without even a heat sink.
+<h2>What this does and does not do</h2>
+This is a direct drop-in replacement for a Raspicam.  Still pictures are captured at
+a lowish rate (1-2 per second) and fed into imgcomp's normal processing.  There is no
+provision for capturing continous video, or at this time even for the experimental
+video clip option of imgcomp.
+<h2>How to set it up</h2>
+First of all, make sure the camera can be accessed over the network.  A completely
+default Hivision camera generally has a static IP address of 192.168.1.10.  To reconfigure
+that you need to at least temporarily set up a 192.168.1.x network, then access the camera
+from a Windows machine with a browser that can run ActiveX (and has all the appropriate security
+overridden to run a grotty binary plugin from who knows where).  Once all that works, go
+and set the camera to the IP address you want, and under "NetService" turm off "Cloud" - you
+don't want to send your video off to China.  All in all, best to keep these cameras on a
+subnet that does not have internet access anyway.
+Once the camera works, you can just open it as a netwok stream in VLC using an URL like
+<p>
+rtsp://IP_ADDRESS:554/user=admin&password=&channel=1&stream=0.sdp
+<p>
+If you see video, you're set.  Now you need to replace the line "aquire_cmd" with the 
+following.
+<p>
+aquire_cmd = ffmpeg -rtsp_transport tcp -i rtsp://IP_ADDRESS:554/user=admin&password=&channel=1&stream=0.sdp -q:v 1 -r 2 /tmp/in2/%06d.jpg<br>
+wait_close_write = 1<br>
+relaunch_timeout = 30<br>
+give_up_timeout = 0<br>
+<p>
+The options are explained in the config section.
+<h2>Multiple Cameras</h2>
+Given that a Raspi can easily handle multiple cameras of this type, support is provided
+for running multiple ones on the same device easily.
+<p>
+For one thing, imgcomp can be started with<p>
+-configfile FILENAME
+<p>
+which will override "imgcomp.conf" as the default configuration.  This way several can be run from the same
+working directory.
+<p>
+Also, in the "www" directory, you can make subdirectories for each camera, with symlinks as follows:
+<p>
+favicon.ico -> ../favicon.ico<br>
+realtime.html -> ../realtime.html<br>
+showpic.js -> ../showpic.js<br>
+tb.cgi -> ../tb.cgi<br>
+view.cgi -> ../view.cgi<br>
+wait_change.cgi -> ../wait_change.cgi<br>
+<p>
+This way, if the stuff in the "browse" directory is recompiled, all the camera directories see it.  Each
+camera directory has the additional links
+<p>
+in -> wherever ffmpeg or rapsistill is dumping its output<br>
+pix -> wherever imgcomp is saving its output<br>
+<p>
+The "pix" link is required for view.cgi to work.  If the "in" link is missing, it defaults to "/ramdisk"
+which is imgcomp's hardwired default.
+<h2>Transferring Pictures Off the Raspi</h2>
+To avoid SD card wear, it is possible to dump imgcomp's output in the RAM disk.  However this requires
+an ancillary script that constantly moves things off the RAM disk to elsewhere on the network.  Such a
+script (which needs customization) is provided the conf-examples directory.

--- a/src/config.h
+++ b/src/config.h
@@ -17,15 +17,16 @@ extern int Verbosity;
 extern char LogToFile[200];
 extern char MoveLogNames[200];
 
-
 extern int Sensitivity;
 extern int Raspistill_restarted;
 extern int TimelapseInterval;
 extern char raspistill_cmd[200];
 extern char blink_cmd[200];
 extern char UdpDest[30];
-
+extern int wait_close_write;
+extern int relaunch_timeout;
+extern int give_up_timeout;
 
 void usage (void);// complain about bad command line 
-void read_config_file(void);
+void read_config_file(char *name);
 int parse_switches (int argc, char **argv, int last_file_arg_seen);


### PR DESCRIPTION
1. Multiple config files instead of hardwired "imgcomp.conf", so that multiple
   instances of imgcomp can be run from the same userid/directory.
2. Several new configuration options so that generic IP cameras (ONVIF/RTSP
   protocol) can be used just like a native Raspi cam.  This requires ffmpeg
   to be installed.
3. Backwards-compatible modifications to the "browse" infrastructure so that
   several cameras can be hosted on the same web server, with live view, etc.
   for all.