### PR TITLE
Added systemd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pdb
 *.jpg
 .*.swp
+imgcomp.service

--- a/imgcomp.service.in
+++ b/imgcomp.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Imgcomp
+After=local-fs.target
+
+[Service]
+User=${USER}
+Restart=always
+Type=simple
+ExecStart=${PREFIX}${BINDIR}/imgcomp -configfile ${CONFIGDIR}${CONFIGFILE}
+
+[Install]
+WantedBy=multi-user.target

--- a/makefile
+++ b/makefile
@@ -5,6 +5,18 @@
 OBJ=obj
 SRC=src
 
+export PREFIX ?= /usr/local
+export BINDIR ?= /bin
+
+export USER ?= pi
+export CONFIGDIR ?= /home/${USER}/.config/imgcomp/
+export CONFIGFILE ?= imgcomp.conf
+
+SYSTEMDSERVICEDIR ?= ${shell pkg-config systemd --variable=systemdsystemconfdir}
+ifeq (,${SYSTEMDSERVICEDIR})
+    $(error Could not retrieve systemd user service directory from pkg-config)
+endif
+
 # with debug:
 #CFLAGS:= $(CFLAGS) -O3 -Wall -g
 
@@ -25,8 +37,28 @@ $(OBJ)/%.o:$(SRC)/%.c $(SRC)/imgcomp.h
 	${CC} $(CFLAGS) -c $< -o $@
 
 imgcomp: $(objs)
-	${CC} -lm -o imgcomp $(objs) -ljpeg
+	${CC} -o imgcomp $(objs) -ljpeg -lm
 
 clean:
-	rm -f $(objs) imgcomp
+	rm -f $(objs) imgcomp imgcomp.service
 
+configdir:
+	@mkdir -p ${CONFIGDIR}
+
+install: imgcomp
+	@install -Dm755 imgcomp ${PREFIX}${BINDIR}/imgcomp
+
+uninstall:
+	rm -f ${PREFIX}${BINDIR}/imgcomp
+
+service: imgcomp.service.in
+	@envsubst < imgcomp.service.in > imgcomp.service
+
+install-service: service configdir install
+	$(info Installing imgcomp.service to ${SYSTEMDSERVICEDIR}/imgcomp.service)
+	@install -Dm644 imgcomp.service ${SYSTEMDSERVICEDIR}/imgcomp.service
+	$(info Run 'sudo systemctl daemon-reload' to register the imgcomp service)
+
+uninstall-service:
+	rm -f ${SYSTEMDSERVICEDIR}/imgcomp.service
+	$(info Run 'sudo systemctl daemon-reload' to remove the imgcomp service)

--- a/setup/setting_up.txt
+++ b/setup/setting_up.txt
@@ -39,6 +39,8 @@ do the following
   cd ~/imgcomp/setup
   ./setup-imgcomp-autorun
 
+Alternatively imgcomp can be set up to run as a service. You can install the service this by running `make install-service`. To start the service, `systemctl start imgcomp`, and to configure the service to run on startup, `systemctl enable imgcomp`.
+
 -----------------------------------------------------------
 HTML based image viewing:
 Configure apache2 and compile the viewing program.


### PR DESCRIPTION
I've been using imgcomp for a few days now and IMO cron is a bit clunky to use to maintain a background process. Systemd is quite easy to use and a big improvement over running with cron.

To better facilitate this I added the ability to install imgcomp in /usr/local/bin.