### PR TITLE
fix path for images directory in setup-browsing

### DIFF
--- a/setup/setup-browsing
+++ b/setup/setup-browsing
@@ -3,7 +3,7 @@
 # Create new web root directory.  These two commands must NOT run as root.
 echo "Make directories for apache2"
 mkdir -p /home/pi/www
-mkdir -p /home/images
+mkdir -p /home/pi/images
 ln -s -f ../images /home/pi/www/pix
 
 


### PR DESCRIPTION
When setting up browsing using the supplied setup-browsing script, the mkdir command failed for the images directory.  Since the soft link to the directory didn't appear as though it should be pointing to /home/images, I assumed the path should be corrected to /home/pi/images.