### PR TITLE
Use keydown event to process keyboard shortcuts

### DIFF
--- a/browse/showpic.js
+++ b/browse/showpic.js
@@ -352,6 +352,7 @@ window.addEventListener("keydown", function (event) {
     return; // Do nothing if the event was already processed
   }
 
+
   switch (event.key) {
     case " ":
       PlayButtonClick();
@@ -361,6 +362,12 @@ window.addEventListener("keydown", function (event) {
       break;
     case "e":
       ShowBigClick();
+      break;
+    case "n":
+      if (NextDir) window.location = "view.cgi?"+NextDir+"/#"+flagsstr
+      break;
+    case "p":
+      if (PrevDir) window.location = "view.cgi?"+PrevDir+"/#"+flagsstr
       break;
     case "s":
       SavePicClick();

--- a/browse/showpic.js
+++ b/browse/showpic.js
@@ -39,7 +39,7 @@ function UpdateActagram(){
 
     if (thisbin == thisbin_last) return;
     thisbin_last = thisbin
-    
+
     // clear canvas so we don't draw on top of it each time
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -346,6 +346,32 @@ vc.onmousemove = picMouseMove
 vc.ontouchstart = picTouchStart
 vc.ontouchend = picTouchEnd
 vc.ontouchmove = picTouchMove
+
+window.addEventListener("keydown", function (event) {
+  if (event.defaultPrevented) {
+    return; // Do nothing if the event was already processed
+  }
+
+  switch (event.key) {
+    case " ":
+      PlayButtonClick();
+      break;
+    case "b":
+      ShowBrightClick();
+      break;
+    case "e":
+      ShowBigClick();
+      break;
+    case "s":
+      SavePicClick();
+      break;
+    default:
+      return; // Quit when this doesn't handle the key event.
+  }
+
+  // Cancel the default action to avoid it being handled twice
+  event.preventDefault();
+}, true);
 
 // Fill bins for actagram (a sort of motion time histogram)
 ActBins = []


### PR DESCRIPTION
Add the following keyboard shortcuts
- " " (spacebar) to toggle play
- "b" to toggle brightness
- "e" to toggle enlarge
- "s" to save pic
- "n" go to next dir
- "p" go to prev dir

Initially I was checking `event.keyCode`: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode


But it seems that is deprecated in favor of `event.key`: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key