### PR TITLE
Use css to render day view actagram

### DIFF
--- a/browse/makefile
+++ b/browse/makefile
@@ -3,7 +3,7 @@ CC=gcc -std=c99 -Wall -DVIEWCGI
 LINKER=link
 LINKCON = /nologo
 
-all:objdir view.cgi wait_change.cgi tb.cgi ../../www/realtime.html ../../www/favicon.ico ../../www/showpic.js
+all:objdir view.cgi wait_change.cgi tb.cgi ../../www/realtime.html ../../www/favicon.ico ../../www/showpic.js ../../www/styledir.css
 
 OBJ = obj
 
@@ -47,3 +47,6 @@ wait_change.cgi:	$(OBJ)/wait_change.o
 
 ../../www/showpic.js: showpic.js
 	cp showpic.js ../../www
+
+../../www/styledir.css: styledir.css
+	cp styledir.css ../../www

--- a/browse/showdir.c
+++ b/browse/showdir.c
@@ -97,7 +97,7 @@ static void ShowHourActagram(VarList SubdImages, char * HtmlPath, char * SubdirN
             char * Name = SubdImages.Entries[BinImage[a]].Name;
             printf("<li>\n<a href=\"view.cgi?%s/%s/#%s\"",HtmlPath, SubdirName, Name);
             printf(" onmouseover=\"mmo('%s/%s')\">",SubdirName, Name);
-            printf("<span class=\"height\" style=\"height: %f%%;\">(%d)</span></a>\n</li>\n", 100.00*Bins[a]/SubdImages.NumEntries, Bins[a]);
+            printf("<span class=\"height\" style=\"height: %f%%;\">(%d)</span></a>\n</li>\n", Bins[a]/6.0*38, Bins[a]);
         }else{
 	    printf("<li></li>\n");
         }
@@ -128,7 +128,6 @@ static int ShowHourlyDirs(char * HtmlPath, int IsRoot, VarList Directories)
         VarList SubdImages;
         char SubdirPath[220];
         memset(&SubdImages, 0, sizeof(VarList));
-
         snprintf(SubdirPath,210,"pix/%s/%s",HtmlPath, SubdirName);
         CollectDirectory(SubdirPath, &SubdImages, NULL, ImageExtensions);
 

--- a/browse/showdir.c
+++ b/browse/showdir.c
@@ -81,7 +81,7 @@ static void ShowHourActagram(VarList SubdImages, char * HtmlPath, char * SubdirN
         int e = strlen(Name);
         if (e < 5 || memcmp(Name+e-4,".jpg",4)) continue; // Not an image.
         NumImages += 1;
- 
+
         Second = (Name[7]-'0')*600 + (Name[8]-'0') * 60
                 +(Name[9]-'0')*10  + (Name[10]-'0');
         binno = Second*NumBins/3600;
@@ -90,24 +90,19 @@ static void ShowHourActagram(VarList SubdImages, char * HtmlPath, char * SubdirN
             BinImage[binno] = a-Bins[binno]/2;
         }
     }
- 
-    printf("<span class='a'>");
+
+    printf("<ul class='histo'>\n");
     for (int a=0;a<NumBins;a++){
         if (Bins[a]){
-            char nc = '-';
-            if (Bins[a] >= 1) nc = '.';
-            if (Bins[a] >= 8) nc = '1';
-            if (Bins[a] >= 25) nc = '2';
-            if (Bins[a] >= 60) nc = '#';
             char * Name = SubdImages.Entries[BinImage[a]].Name;
-            printf("<a href=\"view.cgi?%s/%s/#%s\"",HtmlPath, SubdirName, Name);
-            printf(" onmouseover=\"mmo('%s/%s')\"",SubdirName, Name);
-            printf(">%c</a\n>", nc);
+            printf("<li>\n<a href=\"view.cgi?%s/%s/#%s\"",HtmlPath, SubdirName, Name);
+            printf(" onmouseover=\"mmo('%s/%s')\">",SubdirName, Name);
+            printf("<span class=\"height\" style=\"height: %f%%;\">(%d)</span></a>\n</li>\n", 100.00*Bins[a]/SubdImages.NumEntries, Bins[a]);
         }else{
-            printf("&nbsp;");
+	    printf("<li></li>\n");
         }
     }
-    printf("</span>\n");
+    printf("</ul>\n");
 }
 
 //----------------------------------------------------------------------------------
@@ -116,7 +111,7 @@ static void ShowHourActagram(VarList SubdImages, char * HtmlPath, char * SubdirN
 static int ShowHourlyDirs(char * HtmlPath, int IsRoot, VarList Directories)
 {
     int TotImages = 0;
-    
+
     int prevwkd = 6, thiswkd=6;
     for (int b=0;b<Directories.NumEntries;b++){
         char * SubdirName = Directories.Entries[b].Name;
@@ -133,6 +128,7 @@ static int ShowHourlyDirs(char * HtmlPath, int IsRoot, VarList Directories)
         VarList SubdImages;
         char SubdirPath[220];
         memset(&SubdImages, 0, sizeof(VarList));
+
         snprintf(SubdirPath,210,"pix/%s/%s",HtmlPath, SubdirName);
         CollectDirectory(SubdirPath, &SubdImages, NULL, ImageExtensions);
 
@@ -335,6 +331,7 @@ void MakeHtmlOutput(Dir_t * Dir)
     // Header of file.
     printf("<html>\n<title>%s</title>\n",Dir->HtmlPath);
     printf("<head><meta charset=\"utf-8\"/>\n");
+    printf("<link rel=\"stylesheet\" type=\"text/css\" href=\"styledir.css\">\n");
 
     // Find first image to determine aspect ratio for CSS
     int ThumbnailHeight = 100;
@@ -356,7 +353,6 @@ void MakeHtmlOutput(Dir_t * Dir)
         "  p {margin-bottom: 0px}\n"
         "  span.a {font-family: courier; font-weight: bold; font-size: 14px;}\n"
         "  span.wkend {background-color: #E8E8E8}\n"
-        "  a {text-decoration: none;}\n"
         "  div.ag { float:left; border-left: 1px solid black; margin-bottom:10px; min-width:130px;}\n"
         "  div.pix { float:left; width:321px; height:%dpx;}\n", ThumbnailHeight+45);
     printf("  div.pix img { width: 320; height: %d;", ThumbnailHeight);

--- a/browse/styledir.css
+++ b/browse/styledir.css
@@ -8,10 +8,6 @@ a {
     text-decoration: none;
 }
 
-a:hover {
-    color: #ffffff;
-}
-
 .histo {
     height: 40px;
     width: 330px;

--- a/browse/styledir.css
+++ b/browse/styledir.css
@@ -9,15 +9,16 @@ a {
 }
 
 .histo {
+    overflow: hidden;
     height: 40px;
-    width: 330px;
+    width: 180px;
 }
 
 .histo li {
     height: 38px;
     position: relative;
     float: left;
-    width: 10px;
+    width: 5px;
     margin: 0 0.5px;
 }
 

--- a/browse/styledir.css
+++ b/browse/styledir.css
@@ -1,0 +1,52 @@
+* {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+a {
+    text-decoration: none;
+}
+
+a:hover {
+    color: #ffffff;
+}
+
+.histo {
+    height: 40px;
+    width: 330px;
+}
+
+.histo li {
+    height: 38px;
+    position: relative;
+    float: left;
+    width: 10px;
+    margin: 0 0.5px;
+}
+
+.histo li a {
+    display: block;
+    height: 100%;
+}
+
+.histo li a .height {
+    display: block;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 0;
+    width: 100%;
+    background: #aaaaaa;
+
+    /*https://en.wikipedia.org/wiki/CSS_image_replacement#Implementations*/
+    text-indent: -9999px;
+}
+
+.histo li:hover {
+    background: #efefef;
+}
+
+.histo li a:hover .height {
+    background: #2d7bb2;
+}


### PR DESCRIPTION
This is still a work in progress. Maybe not ready for merging. However, I thought you might want to take a look.

I think this is faster than using canvas. At least it was
faster than my initial brute force attempt.

TODO:
- fix the dirs overview page styling
- try to scale each hourly actagram based on daily max?
- more testing for bugs

Example:
![screenshot 2020-07-04 at 10 43 52 PM](https://user-images.githubusercontent.com/10056608/86525083-e0b2ef80-be47-11ea-87c6-fa64aeafe4e6.jpg)
