### PR TITLE
Fix final message from setup-imgcomp

### DIFF
--- a/setup/setup-imgcomp
+++ b/setup/setup-imgcomp
@@ -66,7 +66,7 @@ fi
 
 if [ ! -d "/ramdisk" ]; then
 	echo
-	echo "You still need to run sudo setup-imgcomp-sudo"
+	echo "You still need to run sudo ./setup-imgcomp-root"
 fi
 
 


### PR DESCRIPTION
When you run `setup-imgcomp`, the final message says "You still need to run sudo setup-imgcomp-sudo". The file is named `setup-imgcomp-root`, so I fixed the message that's printed. Also added `./` to the message.